### PR TITLE
Refactoring

### DIFF
--- a/src/TailwindCssServiceProvider.php
+++ b/src/TailwindCssServiceProvider.php
@@ -17,10 +17,11 @@ class TailwindCssServiceProvider extends PackageServiceProvider
         $package
             ->name('tailwindcss')
             ->hasConfigFile()
-            ->hasCommand(Commands\DownloadCommand::class)
-            ->hasCommand(Commands\InstallCommand::class)
-            ->hasCommand(Commands\BuildCommand::class)
-            ->hasCommand(Commands\WatchCommand::class)
-        ;
+            ->hasCommands([
+                Commands\DownloadCommand::class,
+                Commands\InstallCommand::class,
+                Commands\BuildCommand::class,
+                Commands\WatchCommand::class,
+            ]);
     }
 }


### PR DESCRIPTION
Since there is more than one command in this package, I saw that we can use `hasCommands` method rather than `hasCommand`, because it's readable, and we avoid DRY issue.