### PR TITLE
Fix windows

### DIFF
--- a/config/tailwindcss.php
+++ b/config/tailwindcss.php
@@ -13,7 +13,7 @@ return [
      */
     'build' => [
         'source_file_path' => resource_path('css/app.css'),
-        'destination_file_path' => public_path('dist/css/app.css'),
+        'destination_path' => public_path('dist'),
         'manifest_file_path' => public_path('.tailwindcss-manifest.json'),
     ],
 

--- a/config/tailwindcss.php
+++ b/config/tailwindcss.php
@@ -27,7 +27,7 @@ return [
      | Use the `tailwindcss:download` Artisan command to ensure the binary is there.
      |
      */
-    'bin_path' => base_path('tailwindcss'),
+    'bin_path' => PHP_OS === 'WINNT' ? base_path('tailwindcss.exe') : base_path('tailwindcss'),
 
     /*
      |---------------------------------------------------------------------

--- a/src/Commands/DownloadCommand.php
+++ b/src/Commands/DownloadCommand.php
@@ -8,7 +8,11 @@ use Illuminate\Support\Facades\Http;
 
 class DownloadCommand extends Command
 {
-    protected $signature = 'tailwindcss:download {--force : If the file already exists, we will not touch it. Use this flag if you want to replace it with a new version.}';
+    protected $signature = 'tailwindcss:download
+        {--force : If the file already exists, we will not touch it. Use this flag if you want to replace it with a new version.}
+        {--timeout=600 : Timeout in seconds. Defaults to 5 mins (600s).}
+    ';
+
     protected $description = 'Downloads the Tailwind CSS binary for the version specified in your config/tailwindcss.php.';
 
     public function handle()
@@ -21,6 +25,7 @@ class DownloadCommand extends Command
             'Linux-aarch64' => 'tailwindcss-linux-arm64',
             'Darwin-arm64' => 'tailwindcss-macos-arm64',
             'Darwin-x86_64' => 'tailwindcss-macos-x64',
+            'Windows NT-AMD64' => 'tailwindcss-windows-x64.exe',
         ];
 
         if (! $targetArchitecture = ($architectureToBinary["{$os}-{$cpu}"] ?? false)) {
@@ -40,7 +45,8 @@ class DownloadCommand extends Command
 
         $this->info(sprintf('Downloading the Tailwind CSS binary (%s/%s/%s)...', $os, $cpu, $targetVersion));
 
-        $contents = Http::get($this->downloadUrl($targetArchitecture, $targetVersion))
+        $contents = Http::timeout($this->option('timeout'))
+            ->get($this->downloadUrl($targetArchitecture, $targetVersion))
             ->throw()
             ->body();
 


### PR DESCRIPTION
### Changed

- Changes the `tailwindcss.php` config. Instead of specifying the destination file path, you define a destination PATH, we'll construct the full file path based on the source file relative path.
- The binary destination file now checks if the file destination should end with `.exe` or not (for Windows support)

### Fixed

- Fixes the `tailwindcss:download` and `tailwindcss:build` commands on Windows machines.

### Added

- Increase download default timeout and allow users overriding it with the `--timeout` flag (accepts seconds)