### PR TITLE
Resolve Manifest from container

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -5,6 +5,6 @@ use Tonysm\TailwindCss\Manifest;
 if (! function_exists('tailwindcss')) {
     function tailwindcss(string $path): string
     {
-        return asset((new Manifest())($path));
+        return asset((app(Manifest::class))($path));
     }
 }


### PR DESCRIPTION
I don't want to have to build css assets to run my tests. This is currently the case because the manifest file is required to exist, which isn't always the case for example in CI pipelines. This PR makes it possible to modify this behavior like we can do with Mix.

https://github.com/laravel/framework/blob/9.x/src/Illuminate/Foundation/helpers.php#L559

https://github.com/laravel/framework/blob/9fed2b4a323d9fb74f37d735fadd8f058b0aa37f/src/Illuminate/Foundation/Testing/Concerns/InteractsWithContainer.php#L183
