### PR TITLE
Fix installation command not overriding empty app.css files (default Laravel install)

### DIFF
--- a/config/tailwindcss.php
+++ b/config/tailwindcss.php
@@ -39,5 +39,5 @@ return [
      | @see https://github.com/tailwindlabs/tailwindcss/releases to know the version availables.
      |
      */
-    'version' => env('TAILWINDCSS_CLI_VERSION', 'v3.3.2'),
+    'version' => env('TAILWINDCSS_CLI_VERSION', 'v3.3.5'),
 ];

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -44,10 +44,12 @@ class InstallCommand extends Command
                 to: base_path('tailwind.config.js'),
             );
 
-            $this->copyStubToAppIfMissing(
-                stub: __DIR__ . '/../../stubs/resources/css/app.css',
-                to: resource_path('css/app.css'),
-            );
+            if (! File::exists($appCssFilePath = resource_path('css/app.css')) || empty(trim(File::get($appCssFilePath)))) {
+                $this->copyStubToApp(
+                    stub: __DIR__ . '/../../stubs/resources/css/app.css',
+                    to: $appCssFilePath,
+                );
+            }
 
             return self::SUCCESS;
         });


### PR DESCRIPTION
### Fixed

- Fixes the install command not overriding the default `resources/css/app.css` file that ships with Laravel, even though it's empty

### Changed

- Bumps the default TailwindCSS bin version installation