### PR TITLE
Fix tty not read/writable on build command inside Docker

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
 use Tonysm\TailwindCss\Manifest;
+use Symfony\Component\Process\Process as SymfonyProcess;
 
 class BuildCommand extends Command
 {
@@ -48,7 +49,7 @@ class BuildCommand extends Command
         }
 
         Process::forever()
-            ->tty(PHP_OS != 'WINNT' && is_writable('/dev/tty'))
+            ->tty(SymfonyProcess::isTtySupported())
             ->path(base_path())
             ->run(array_filter([
                 $binFile,

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
 use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process as SymfonyProcess;
 use Tonysm\TailwindCss\Actions\AppendTailwindTag;
 
 class InstallCommand extends Command
@@ -53,7 +54,7 @@ class InstallCommand extends Command
     private function ensureTailwindCliBinaryExists()
     {
         if (! File::exists(config('tailwindcss.bin_path')) || $this->option('download')) {
-            Process::forever()->tty(PHP_OS != 'WINNT' && is_writable('/dev/tty'))->run([
+            Process::forever()->tty(SymfonyProcess::isTtySupported())->run([
                 $this->phpBinary(),
                 'artisan',
                 'tailwindcss:download',
@@ -168,7 +169,7 @@ class InstallCommand extends Command
 
     private function runFirstBuild()
     {
-        Process::forever()->tty(PHP_OS != 'WINNT' && is_writable('/dev/tty'))->run([
+        Process::forever()->tty(SymfonyProcess::isTtySupported())->run([
             $this->phpBinary(),
             'artisan',
             'tailwindcss:build',


### PR DESCRIPTION
I got the error
```
TTY mode requires /dev/tty to be read/writable
```

when running 
```
php artisan tailwindcss:build --prod
```

inside a dockerfile based on dunglas/frankenphp:latest-alpine (I guess it would also happen with the official base php docker images).

This patch uses the Symfony Process tty check to more reliably check if the tty is available.