### PR TITLE
Add documentation about the install step

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ There are some files needed for the setup to work. On a fresh Laravel applicatio
 php artisan tailwindcss:install
 ```
 
-This will ensure there's a `tailwind.config.js` file at the root of your project, as well as a `resources/css/app.css` file with the basic Tailwind CSS setup.
+This adds a `resources/css/app.css` file preconfigured with Tailwind CSS. It also removes any existing `tailwind.config.js` file because, starting with Tailwind CSS v4.0, there is a [CSS‑first configuration](https://tailwindcss.com/blog/tailwindcss-v4#css-first-configuration) approach by default.
 
 ### Building
 


### PR DESCRIPTION
Love the package. As someone not very invested in front-end it's a nice quick tool to generate the CSS for a project that does not have Next.js running on the server. 

I had an older project with a `taiwind.config.js` file and could not figure out why it got deleted every time I ran `artisan tailwindcss:install`. When diving in the source code I saw it got deleted, but that contradicted the documentation. So hopefully with this small addition I hope that new users will find their way around quicker. 

