### PR TITLE
Adds the `no-tty` flag

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -16,6 +16,7 @@ class BuildCommand extends Command
         {--minify : If you want the final CSS file to be minified.}
         {--digest : If you want the final CSS file to be generated using a digest of its contents (does not work with the --watch flag).}
         {--prod : This option combines the --minify and --digest options. Ideal for production.}
+        {--no-tty : Disables TTY output mode. Use this in environments where TTY is not supported or causing issues.}
     ';
 
     protected $description = 'Generates a new build of Tailwind CSS for your project.';
@@ -49,7 +50,10 @@ class BuildCommand extends Command
         }
 
         Process::forever()
-            ->tty(SymfonyProcess::isTtySupported())
+            ->when(
+                ! $this->option('no-tty'),
+                fn ($process) => $process->tty(SymfonyProcess::isTtySupported())
+            )
             ->path(base_path())
             ->run(array_filter([
                 $binFile,

--- a/src/Commands/WatchCommand.php
+++ b/src/Commands/WatchCommand.php
@@ -6,7 +6,9 @@ use Illuminate\Console\Command;
 
 class WatchCommand extends Command
 {
-    protected $signature = 'tailwindcss:watch';
+    protected $signature = 'tailwindcss:watch
+        {--no-tty : Disables TTY output mode. Use this in environments where TTY is not supported or causing issues.}
+    ';
 
     protected $description = 'Generates a new build of Tailwind CSS for your project, and keeps watching your files changes.';
 
@@ -14,6 +16,7 @@ class WatchCommand extends Command
     {
         return $this->call('tailwindcss:build', [
             '--watch' => true,
+            '--no-tty' => $this->option('no-tty'),
         ]);
     }
 }


### PR DESCRIPTION
There is an odd behavior with tty and certain envs (such as MacOS), by passing this flag it enables tailwind v4 to work as expected.

## Related
- https://github.com/tonysm/tailwindcss-laravel/issues/36#issuecomment-2643352041